### PR TITLE
V1.3.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/automixer/gtexporter
 go 1.23.2
 
 require (
-	github.com/golang/glog v1.2.2
+	github.com/golang/glog v1.2.3
 	github.com/openconfig/gnmi v0.11.0
 	github.com/openconfig/ygot v0.29.20
 	github.com/prometheus/client_golang v1.20.5

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,8 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20210512163311-63b5d3c536b0/go.m
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
-github.com/golang/glog v1.2.2 h1:1+mZ9upx1Dh6FmUTFR1naJ77miKiXgALjWOZ3NVFPmY=
-github.com/golang/glog v1.2.2/go.mod h1:6AhwSGph0fcJtXVM/PEHPqZlFeoLxhs7/t5UDAwmO+w=
+github.com/golang/glog v1.2.3 h1:oDTdz9f5VGVVNGu/Q7UXKWYsD0873HXLHdJUNBsSEKM=
+github.com/golang/glog v1.2.3/go.mod h1:6AhwSGph0fcJtXVM/PEHPqZlFeoLxhs7/t5UDAwmO+w=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/pkg/plugins/ocinterfaces/ocifformatter.go
+++ b/pkg/plugins/ocinterfaces/ocifformatter.go
@@ -32,13 +32,14 @@ func init() {
 }
 
 type ocIfFormatter struct {
-	config        plugins.Config
-	root          *ysocif.Root
-	lagTable      map[string]string // Key: ifName, Value: LAG name
-	lagSet        map[string]bool   // Key: lagName
-	disableInt    bool
-	disableAgg    bool
-	disableSubInt bool
+	config            plugins.Config
+	root              *ysocif.Root
+	lagTable          map[string]string // Key: ifName, Value: LAG name
+	lagSet            map[string]bool   // Key: lagName
+	disableInt        bool
+	disableAgg        bool
+	disableSubInt     bool
+	fillLagMemberDesc bool
 }
 
 func newFormatter(cfg plugins.Config) (plugins.Formatter, error) {
@@ -47,6 +48,7 @@ func newFormatter(cfg plugins.Config) (plugins.Formatter, error) {
 	f.disableInt, _ = strconv.ParseBool(f.config.Options["disable_int"])
 	f.disableAgg, _ = strconv.ParseBool(f.config.Options["disable_agg"])
 	f.disableSubInt, _ = strconv.ParseBool(f.config.Options["disable_subint"])
+	f.fillLagMemberDesc, _ = strconv.ParseBool(f.config.Options["fill_lag_member_desc"])
 	return f, nil
 }
 
@@ -186,7 +188,7 @@ func (f *ocIfFormatter) ifCounters() []exporter.GMetric {
 			metric.IfType = iface.GetType().ShortString()
 			metric.LagType = lagType
 			metric.Description = iface.GetDescription()
-			if metric.Description == "" && kind == kindIfaceLagMember {
+			if f.fillLagMemberDesc && metric.Description == "" && kind == kindIfaceLagMember {
 				// Copy the parent's description
 				metric.Description = f.root.Interface[alias].GetDescription()
 			}
@@ -242,7 +244,7 @@ func (f *ocIfFormatter) ifGauges() []exporter.GMetric {
 			metric.IfType = iface.GetType().ShortString()
 			metric.LagType = lagType
 			metric.Description = iface.GetDescription()
-			if metric.Description == "" && kind == kindIfaceLagMember {
+			if f.fillLagMemberDesc && metric.Description == "" && kind == kindIfaceLagMember {
 				// Copy the parent's description
 				metric.Description = f.root.Interface[alias].GetDescription()
 			}
@@ -301,7 +303,7 @@ func (f *ocIfFormatter) subIfCounters() []exporter.GMetric {
 				metric.OperStatus = subIface.GetOperStatus().ShortString()
 				metric.LagType = lagType
 				metric.Description = subIface.GetDescription()
-				if metric.Description == "" && kind == kindSubIfaceLagMember {
+				if f.fillLagMemberDesc && metric.Description == "" && kind == kindSubIfaceLagMember {
 					// Copy the parent's description
 					metric.Description = f.root.Interface[alias].Subinterface[index].GetDescription()
 				}
@@ -358,7 +360,7 @@ func (f *ocIfFormatter) subIfGauges() []exporter.GMetric {
 				metric.OperStatus = subIface.GetOperStatus().ShortString()
 				metric.LagType = lagType
 				metric.Description = subIface.GetDescription()
-				if metric.Description == "" && kind == kindSubIfaceLagMember {
+				if f.fillLagMemberDesc && metric.Description == "" && kind == kindSubIfaceLagMember {
 					// Copy the parent's description
 					metric.Description = f.root.Interface[alias].Subinterface[index].GetDescription()
 				}

--- a/pkg/plugins/ocinterfaces/ocifformatter.go
+++ b/pkg/plugins/ocinterfaces/ocifformatter.go
@@ -293,6 +293,10 @@ func (f *ocIfFormatter) subIfCounters() []exporter.GMetric {
 				metric.OperStatus = subIface.GetOperStatus().ShortString()
 				metric.LagType = lagType
 				metric.Description = subIface.GetDescription()
+				if metric.Description == "" && kind == kindSubIfaceLagMember {
+					// Copy the parent's description
+					metric.Description = f.root.Interface[alias].GetDescription()
+				}
 				// Values
 				metric.Metric = counterName
 				metric.Value = counterValue
@@ -346,6 +350,10 @@ func (f *ocIfFormatter) subIfGauges() []exporter.GMetric {
 				metric.OperStatus = subIface.GetOperStatus().ShortString()
 				metric.LagType = lagType
 				metric.Description = subIface.GetDescription()
+				if metric.Description == "" && kind == kindSubIfaceLagMember {
+					// Copy the parent's description
+					metric.Description = f.root.Interface[alias].GetDescription()
+				}
 				// Values
 				metric.Metric = gaugeName
 				metric.Value = gaugeValue

--- a/pkg/plugins/ocinterfaces/ocifformatter.go
+++ b/pkg/plugins/ocinterfaces/ocifformatter.go
@@ -295,7 +295,7 @@ func (f *ocIfFormatter) subIfCounters() []exporter.GMetric {
 				metric.Description = subIface.GetDescription()
 				if metric.Description == "" && kind == kindSubIfaceLagMember {
 					// Copy the parent's description
-					metric.Description = f.root.Interface[alias].GetDescription()
+					metric.Description = f.root.Interface[alias].Subinterface[index].GetDescription()
 				}
 				// Values
 				metric.Metric = counterName
@@ -352,7 +352,7 @@ func (f *ocIfFormatter) subIfGauges() []exporter.GMetric {
 				metric.Description = subIface.GetDescription()
 				if metric.Description == "" && kind == kindSubIfaceLagMember {
 					// Copy the parent's description
-					metric.Description = f.root.Interface[alias].GetDescription()
+					metric.Description = f.root.Interface[alias].Subinterface[index].GetDescription()
 				}
 				// Values
 				metric.Metric = gaugeName

--- a/pkg/plugins/ocinterfaces/ocifformatter.go
+++ b/pkg/plugins/ocinterfaces/ocifformatter.go
@@ -186,6 +186,10 @@ func (f *ocIfFormatter) ifCounters() []exporter.GMetric {
 			metric.IfType = iface.GetType().ShortString()
 			metric.LagType = lagType
 			metric.Description = iface.GetDescription()
+			if metric.Description == "" && kind == kindIfaceLagMember {
+				// Copy the parent's description
+				metric.Description = f.root.Interface[alias].GetDescription()
+			}
 			// Values
 			metric.Metric = counterName
 			metric.Value = counterValue
@@ -238,6 +242,10 @@ func (f *ocIfFormatter) ifGauges() []exporter.GMetric {
 			metric.IfType = iface.GetType().ShortString()
 			metric.LagType = lagType
 			metric.Description = iface.GetDescription()
+			if metric.Description == "" && kind == kindIfaceLagMember {
+				// Copy the parent's description
+				metric.Description = f.root.Interface[alias].GetDescription()
+			}
 			// Values
 			metric.Metric = gaugeName
 			metric.Value = gaugeValue

--- a/plugin-options.yaml
+++ b/plugin-options.yaml
@@ -25,6 +25,8 @@ devices:
                                       # Only interface records satisfying this regexp are passed.
       index_filter: ".*"              # subInterface's index regexp filter.
                                       # Only subInterface records satisfying this regexp are passed.
+      fill_lag_member_desc: "false"   # If the LAG member description is empty, overwrite it with the parent's desc.
+                                      # Specific for Juniper devices. Could also work with other platforms.
 ---
 #==== oc_lldp specific ====
       disable_gnmi_delete: "true"     # Disables the processing of gNMI delete messages.


### PR DESCRIPTION
# New feature for OpenConfig Interfaces plugin.
When processing ```interfaces``` and ```subinterfaces``` LAG member entries, the plugin's ```formatter```  looks at the ```description``` field. If empty, the ```formatter``` will copy the description from the parent LAG ```interface``` or ```subinterface```.  
This feature is specific for Juniper Networks devices but could also work with other platforms.  
The feature can be enabled with a new configurational key named ```fill_lag_member_desc```.
